### PR TITLE
Add replacer to handle non-string conversions

### DIFF
--- a/parse.ts
+++ b/parse.ts
@@ -32,7 +32,7 @@ const ENTITIES = {
   "&gt;": ">",
   "&apos;": "'",
   "&quot;": '"',
-  "&amp;": "&",
+  "&amp;": "&", //Keep last
 };
 const ENTITIES_DEC = /&#(?<code>\d+);/g;
 const ENTITIES_HEX = /&#x(?<code>\d+);/g;

--- a/stringify_test.ts
+++ b/stringify_test.ts
@@ -121,3 +121,35 @@ Deno.test("stringify: xml example w3schools.com#3", () =>
       },
     },
   ));
+
+Deno.test("stringify: xml types", () =>
+  assertEquals(
+    check(
+      `
+  <types>
+    <boolean>true</boolean>
+    <null></null>
+    <string>hello</string>
+  </types>
+`,
+    ),
+    {
+      types: {
+        boolean: true,
+        null: null,
+        string: "hello",
+      },
+    },
+  ));
+
+Deno.test("stringify: xml entities", () =>
+  assertEquals(
+    check(
+      `
+    <string>&quot; &lt; &gt; &amp; &apos;</string>
+`,
+    ),
+    {
+      string: `" < > & '`,
+    },
+  ));


### PR DESCRIPTION
Fixes #3 

Add a replacer to handle non-string values, along with html entities