### PR TITLE
chore: centralize test dependencies

### DIFF
--- a/parse_test.ts
+++ b/parse_test.ts
@@ -1,8 +1,5 @@
 import { $XML, parse } from "./mod.ts";
-import { asserts } from "./test_deps.ts";
-
-const assert: (expr: unknown) => asserts expr = asserts.assert;
-const { assertEquals, assertThrows } = asserts;
+import { assert, assertEquals, assertThrows } from "./test_deps.ts";
 
 // deno-lint-ignore no-explicit-any
 type test = any;

--- a/parse_test.ts
+++ b/parse_test.ts
@@ -1,5 +1,8 @@
 import { $XML, parse } from "./mod.ts";
-import { assert, assertEquals, assertThrows } from "https://deno.land/std@0.111.0/testing/asserts.ts";
+import { asserts } from "./test_deps.ts";
+
+const assert: (expr: unknown) => asserts expr = asserts.assert;
+const { assertEquals, assertThrows } = asserts;
 
 // deno-lint-ignore no-explicit-any
 type test = any;

--- a/stringify_test.ts
+++ b/stringify_test.ts
@@ -1,5 +1,7 @@
 import { parse, stringify } from "./mod.ts";
-import { assertEquals } from "https://deno.land/std@0.111.0/testing/asserts.ts";
+import { asserts } from "./test_deps.ts";
+
+const { assertEquals } = asserts;
 
 /** This operation ensure that reforming a parsed XML will still yield same data */
 //deno-lint-ignore no-explicit-any

--- a/stringify_test.ts
+++ b/stringify_test.ts
@@ -1,7 +1,5 @@
 import { parse, stringify } from "./mod.ts";
-import { asserts } from "./test_deps.ts";
-
-const { assertEquals } = asserts;
+import { assertEquals } from "./test_deps.ts";
 
 /** This operation ensure that reforming a parsed XML will still yield same data */
 //deno-lint-ignore no-explicit-any

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,3 +1,3 @@
-export * as asserts from "https://deno.land/std@0.116.0/testing/asserts.ts";
-export * as bench from "https://deno.land/std@0.116.0/testing/bench.ts";
+export { assert, assertEquals, assertThrows } from "https://deno.land/std@0.116.0/testing/asserts.ts";
+export { bench, runBenchmarks } from "https://deno.land/std@0.116.0/testing/bench.ts";
 export { expandGlob } from "https://deno.land/std@0.116.0/fs/expand_glob.ts";

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,0 +1,3 @@
+export * as asserts from "https://deno.land/std@0.111.0/testing/asserts.ts";
+export * as bench from "https://deno.land/std@0.111.0/testing/bench.ts";
+export * as expandGlob from "https://deno.land/std@0.111.0/fs/expand_glob.ts";

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,3 +1,3 @@
 export * as asserts from "https://deno.land/std@0.116.0/testing/asserts.ts";
 export * as bench from "https://deno.land/std@0.116.0/testing/bench.ts";
-export * as expandGlob from "https://deno.land/std@0.116.0/fs/expand_glob.ts";
+export { expandGlob } from "https://deno.land/std@0.116.0/fs/expand_glob.ts";

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,3 +1,3 @@
-export * as asserts from "https://deno.land/std@0.111.0/testing/asserts.ts";
-export * as bench from "https://deno.land/std@0.111.0/testing/bench.ts";
-export * as expandGlob from "https://deno.land/std@0.111.0/fs/expand_glob.ts";
+export * as asserts from "https://deno.land/std@0.116.0/testing/asserts.ts";
+export * as bench from "https://deno.land/std@0.116.0/testing/bench.ts";
+export * as expandGlob from "https://deno.land/std@0.116.0/fs/expand_glob.ts";

--- a/utils/tests/benchmark.ts
+++ b/utils/tests/benchmark.ts
@@ -1,9 +1,6 @@
 //Imports
-import { bench as benchLib, expandGlob as expandGlobLib } from "../../test_deps.ts";
+import { bench, runBenchmarks, expandGlob } from "../../test_deps.ts";
 import { parse } from "../../mod.ts";
-
-const { bench, runBenchmarks } = benchLib;
-const { expandGlob } = expandGlobLib;
 
 //Huge xml file generator
 async function write({ path, size }: { path: string; size: number }) {

--- a/utils/tests/benchmark.ts
+++ b/utils/tests/benchmark.ts
@@ -1,7 +1,9 @@
 //Imports
-import { bench, runBenchmarks } from "https://deno.land/std@0.111.0/testing/bench.ts";
-import { expandGlob } from "https://deno.land/std@0.111.0/fs/expand_glob.ts";
+import { bench as benchLib, expandGlob as expandGlobLib } from "../../test_deps.ts";
 import { parse } from "../../mod.ts";
+
+const { bench, runBenchmarks } = benchLib;
+const { expandGlob } = expandGlobLib;
 
 //Huge xml file generator
 async function write({ path, size }: { path: string; size: number }) {

--- a/utils/utils_test.ts
+++ b/utils/utils_test.ts
@@ -1,7 +1,9 @@
 import { Streamable } from "./streamable.ts";
 import { Stream } from "./stream.ts";
 import { SeekMode } from "./types.ts";
-import { assertEquals, assertThrows } from "https://deno.land/std@0.111.0/testing/asserts.ts";
+import { asserts } from "../test_deps.ts";
+
+const { assertEquals, assertThrows } = asserts;
 
 Deno.test("streamable: readSync", () => {
   const stream = new Streamable("hello world");

--- a/utils/utils_test.ts
+++ b/utils/utils_test.ts
@@ -1,9 +1,7 @@
 import { Streamable } from "./streamable.ts";
 import { Stream } from "./stream.ts";
 import { SeekMode } from "./types.ts";
-import { asserts } from "../test_deps.ts";
-
-const { assertEquals, assertThrows } = asserts;
+import { assertEquals, assertThrows } from "../test_deps.ts";
 
 Deno.test("streamable: readSync", () => {
   const stream = new Streamable("hello world");


### PR DESCRIPTION
Centralize test deps to a `test_deps.ts` file and upgrade them to std 0.116.0.

Happy to change the style used here, as approaches seem to vary widely between different Deno projects.