### PR TITLE
fix: child indentation and comment array for `stringify`

### DIFF
--- a/stringify_test.ts
+++ b/stringify_test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from "./test_deps.ts";
 //deno-lint-ignore no-explicit-any
 const check = (xml: string, options: any = {}) => {
   assertEquals(stringify(parse(xml, options), options), xml);
+  //deno-lint-ignore no-explicit-any
   return parse(stringify(parse(xml, options) as any, options), options);
 }
 

--- a/stringify_test.ts
+++ b/stringify_test.ts
@@ -3,15 +3,16 @@ import { assertEquals } from "./test_deps.ts";
 
 /** This operation ensure that reforming a parsed XML will still yield same data */
 //deno-lint-ignore no-explicit-any
-const check = (xml: string, options: any = {}) => parse(stringify(parse(xml, options) as any, options), options);
+const check = (xml: string, options: any = {}) => {
+  assertEquals(stringify(parse(xml, options), options), xml);
+  return parse(stringify(parse(xml, options) as any, options), options);
+}
 
 Deno.test("stringify: xml syntax xml prolog", () =>
   assertEquals(
     check(
-      `
-  <?xml version="1.0" encoding="UTF-8"?>
-  <root></root>
-`,
+`<?xml version="1" encoding="UTF-8"?>
+<root/>`,
     ),
     {
       xml: {
@@ -25,10 +26,8 @@ Deno.test("stringify: xml syntax xml prolog", () =>
 Deno.test("stringify: xml syntax doctype", () =>
   assertEquals(
     check(
-      `
-  <!DOCTYPE type "quoted attribute">
-  <root></root>
-`,
+`<!DOCTYPE type "quoted attribute">
+<root/>`,
     ),
     {
       doctype: {
@@ -41,42 +40,45 @@ Deno.test("stringify: xml syntax doctype", () =>
 
 Deno.test("stringify: xml example w3schools.com#3", () =>
   assertEquals(
-    check(`
-  <bookstore>
-    <book category="cooking">
-      <title lang="en">Everyday Italian</title>
-      <author>Giada De Laurentiis</author>
-      <year>2005</year>
-      <price>30.00</price>
-    </book>
-    <book category="children">
-      <title lang="en">Harry Potter</title>
-      <author>J K. Rowling</author>
-      <year>2005</year>
-      <price>29.99</price>
-    </book>
-    <book category="web">
-      <title lang="en">XQuery Kick Start</title>
-      <author>James McGovern</author>
-      <author>Per Bothner</author>
-      <author>Kurt Cagle</author>
-      <author>James Linn</author>
-      <author>Vaidyanathan Nagarajan</author>
-      <year>2003</year>
-      <price>49.99</price>
-    </book>
-    <book category="web" cover="paperback">
-      <title lang="en">Learning XML</title>
-      <author>Erik T. Ray</author>
-      <year>2003</year>
-      <price>39.95</price>
-    </book>
-  </bookstore>
-`),
+    check(
+`<bookstore>
+  <book category="cooking">
+    <!-- Comment Node -->
+    <title lang="en">Everyday Italian</title>
+    <author>Giada De Laurentiis</author>
+    <year>2005</year>
+    <price>30</price>
+  </book>
+  <book category="children">
+    <!-- First Comment Node -->
+    <!-- Second Comment Node -->
+    <title lang="en">Harry Potter</title>
+    <author>J K. Rowling</author>
+    <year>2005</year>
+    <price>29.99</price>
+  </book>
+  <book category="web">
+    <title lang="en">XQuery Kick Start</title>
+    <author>James McGovern</author>
+    <author>Per Bothner</author>
+    <author>Kurt Cagle</author>
+    <author>James Linn</author>
+    <author>Vaidyanathan Nagarajan</author>
+    <year>2003</year>
+    <price>49.99</price>
+  </book>
+  <book category="web" cover="paperback">
+    <title lang="en">Learning XML</title>
+    <author>Erik T. Ray</author>
+    <year>2003</year>
+    <price>39.95</price>
+  </book>
+</bookstore>`),
     {
       bookstore: {
         book: [
           {
+            "#comment": "Comment Node",
             "@category": "cooking",
             title: { "@lang": "en", "#text": "Everyday Italian" },
             author: "Giada De Laurentiis",
@@ -84,6 +86,7 @@ Deno.test("stringify: xml example w3schools.com#3", () =>
             price: 30,
           },
           {
+            "#comment": ["First Comment Node", "Second Comment Node"],
             "@category": "children",
             title: { "@lang": "en", "#text": "Harry Potter" },
             author: "J K. Rowling",
@@ -119,13 +122,11 @@ Deno.test("stringify: xml example w3schools.com#3", () =>
 Deno.test("stringify: xml types", () =>
   assertEquals(
     check(
-      `
-  <types>
-    <boolean>true</boolean>
-    <null></null>
-    <string>hello</string>
-  </types>
-`,
+`<types>
+  <boolean>true</boolean>
+  <null/>
+  <string>hello</string>
+</types>`,
     ),
     {
       types: {
@@ -138,11 +139,7 @@ Deno.test("stringify: xml types", () =>
 
 Deno.test("stringify: xml entities", () =>
   assertEquals(
-    check(
-      `
-    <string>&quot; &lt; &gt; &amp; &apos;</string>
-`,
-    ),
+    check(`<string>&quot; &lt; &gt; &amp; &apos;</string>`),
     {
       string: `" < > & '`,
     },
@@ -158,10 +155,8 @@ Deno.test("stringify: xml replacer", () =>
         return value;
       },
     }),
-    `
-<root>
+`<root>
   <not>false</not>
   <yes>true</yes>
-</root>
-`.trim(),
+</root>`.trim(),
   ));

--- a/utils/stringifier.ts
+++ b/utils/stringifier.ts
@@ -131,7 +131,9 @@ export class Stringifier {
       //Handle comments
       if (comments.length) {
         this.#debug(path, `stringifying comments`);
-        for (const comment of comments) {
+        const commentArr = Array.isArray(comments) ? comments : [comments];
+        for (const comment of commentArr) {
+          this.#write("\n", { newline: false, indent: false });
           this.#comment({ text: comment, tag: name });
         }
       }
@@ -161,6 +163,9 @@ export class Stringifier {
           const child = node[name];
           handle({ child, name });
         }
+
+        // indentation fix - if had children, cant be inline
+        inline = false;
       }
     }
 
@@ -176,7 +181,7 @@ export class Stringifier {
   /** Comment stringifier */
   #comment({ text, tag }: { text: string; tag: string }) {
     const comment = this.#replace({ value: text, key: schema.comment, tag, properties: null });
-    this.#write(`${tokens.comment.start} ${comment} ${tokens.comment.end}`);
+    this.#write(`${tokens.comment.start} ${comment} ${tokens.comment.end}`, { newline: false });
   }
 
   /** Text stringifier */


### PR DESCRIPTION
This is a fix for two issues:

- `stringify` indentation was incorrect for an `</end>` element if it was wrapping children
- `stringify` for comments functioned incorrectly if the input was not an array, which is supported by `parse`

For `stringify_test.ts`, I added an additional assertion for all tests that use `check` such that the input string's format is also tested.

