### PR TITLE
Fix: Properties are not only delimited by spaces or quotes

### DIFF
--- a/utils/parser.ts
+++ b/utils/parser.ts
@@ -313,16 +313,18 @@ export class Parser {
     this.#debug(path, "parsing property")
 
     //Property name
+    let property
+
     const quote = this.#stream.peek()
-    const delimiter = /["']/.test(quote) ? quote : " "
-    if (delimiter.trim().length) {
-      this.#consume(delimiter)
+    if (/["']/.test(quote)) {
+      this.#consume(quote)
+      property = this.#capture({ until: new RegExp(quote), bytes: 1 })
+      this.#consume(quote)
+    } else {
+      property = this.#capture({ until: /[\s>]/, bytes: 1 })
     }
-    const property = this.#capture({ until: new RegExp(delimiter), bytes: delimiter.length })
+
     this.#debug(path, `found property ${property}`)
-    if (delimiter.trim().length) {
-      this.#consume(delimiter)
-    }
 
     //Result
     return { [`${schema.property.prefix}${property}`]: true }


### PR DESCRIPTION
# Change

I tried to parse the following nmap xml

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE nmaprun>
<?xml-stylesheet href="file:///usr/bin/../share/nmap/nmap.xsl" type="text/xsl"?>
...
```

when parsing the `nmaprun` property inside the doctype it continued the property until the space in the next line. This is reproducible whenever the property is not in quotes and is the last thing before the closing `>`