### PR TITLE
fix: prevent hanging when the first character is invalid

### DIFF
--- a/parse_test.ts
+++ b/parse_test.ts
@@ -494,6 +494,21 @@ Deno.test("parse: xml syntax attributes properly quoted", () =>
 `)
   ))
 
+Deno.test("parse: xml syntax first character", () => {
+  assertThrows(() =>
+    parse(`a>1</a>`)
+  )
+  assertThrows(() =>
+    parse(`xml`)
+  )
+  assertThrows(() =>
+    parse(`""`)
+  )
+  assertThrows(() =>
+    parse(`{a: 1}`)
+  )
+})
+
 //Example below were taken from https://www.w3schools.com/xml/default.asp
 
 Deno.test("parse: xml example w3schools.com#1", () =>

--- a/utils/parser.ts
+++ b/utils/parser.ts
@@ -57,7 +57,7 @@ export class Parser {
         }
 
         //Extract prolog, stylesheets and doctype
-        if ((this.#peek(tokens.prolog.start)) && (!this.#peek(tokens.stylesheet.start))) {
+        else if ((this.#peek(tokens.prolog.start)) && (!this.#peek(tokens.stylesheet.start))) {
           if (document.xml) {
             throw Object.assign(new SyntaxError("Multiple prolog declaration found"), { stack: false })
           }
@@ -65,13 +65,13 @@ export class Parser {
           Object.assign(document, this.#prolog({ path }))
           continue
         }
-        if (this.#peek(tokens.stylesheet.start)) {
+        else if (this.#peek(tokens.stylesheet.start)) {
           clean = false
           const stylesheets = (document[schema.stylesheets] ??= []) as unknown[]
           stylesheets.push(this.#stylesheet({ path }).stylesheet)
           continue
         }
-        if (this.#peek(tokens.doctype.start)) {
+        else if (this.#peek(tokens.doctype.start)) {
           if (document.doctype) {
             throw Object.assign(new SyntaxError("Multiple doctype declaration found"), { stack: false })
           }
@@ -81,7 +81,7 @@ export class Parser {
         }
 
         //Extract root node
-        if (this.#peek(tokens.tag.start)) {
+        else if (this.#peek(tokens.tag.start)) {
           if (root) {
             throw Object.assign(new SyntaxError("Multiple root elements found"), { stack: false })
           }
@@ -90,6 +90,10 @@ export class Parser {
           this.#trim()
           root = true
           continue
+        }
+
+        else {
+          throw Object.assign(new SyntaxError("Invalid XML structure"), { stack: false })
         }
       }
     } catch (error) {


### PR DESCRIPTION
Fixes #28

Apparently, when the very first character of the XML was different from `<`, parsing would fall into an infinite loop. I'm not sure if anything other than the first character could cause the same issue.

Let me know if we can throw a better error message.