### PR TITLE
BREAKING: change EOF errors from `Deno.errors.UnexpectedEof` to `RangeError("Unexpected EOF")`

### DIFF
--- a/parse_test.ts
+++ b/parse_test.ts
@@ -2,7 +2,6 @@ import { $XML, parse } from "./mod.ts"
 import { expect } from "https://deno.land/std@0.223.0/expect/expect.ts"
 import { fn } from "https://deno.land/std@0.223.0/expect/fn.ts"
 import type { ParserOptions } from "./utils/types.ts"
-import { EofError } from "./utils/types.ts"
 
 // deno-lint-ignore no-explicit-any
 type test = any
@@ -512,7 +511,7 @@ Deno.test("parse: xml syntax attributes quoted", () =>
     <child test=hey></child>
   </root>
 `)
-  ).toThrow(EofError))
+  ).toThrow(RangeError))
 
 Deno.test("parse: xml syntax attributes properly quoted", () =>
   expect(() =>
@@ -521,7 +520,7 @@ Deno.test("parse: xml syntax attributes properly quoted", () =>
     <child test="hey></child>
   </root>
 `)
-  ).toThrow(EofError))
+  ).toThrow(RangeError))
 
 Deno.test("parse: xml syntax first character", () => {
   expect(() => parse(`a>1</a>`)).toThrow(SyntaxError)

--- a/utils/parser.ts
+++ b/utils/parser.ts
@@ -1,6 +1,6 @@
 //Imports
 import type { Stream } from "./stream.ts"
-import { $XML, entities, EofError, schema, tokens } from "./types.ts"
+import { $XML, entities, schema, tokens } from "./types.ts"
 import type { node, ParserOptions } from "./types.ts"
 
 /**
@@ -89,7 +89,7 @@ export class Parser {
         }
       }
     } catch (error) {
-      if ((error instanceof EofError) && clean) {
+      if ((error instanceof RangeError) && clean) {
         if (comments.length) {
           document[schema.comment] = comments
         }

--- a/utils/stream.ts
+++ b/utils/stream.ts
@@ -1,6 +1,6 @@
 //Imports
 import type { Flux } from "./types.ts"
-import { EofError, SeekMode } from "./types.ts"
+import { SeekMode } from "./types.ts"
 
 /**
  * Text stream helper
@@ -36,7 +36,7 @@ export class Stream {
       this.#content.seekSync(cursor, SeekMode.Start)
       return this.#decoder.decode(buffer)
     }
-    throw new EofError()
+    throw Object.assign(new RangeError("Unexpected EOF"), { stack: false })
   }
 
   /** Read next bytes (cursor is moved after reading) */
@@ -45,7 +45,7 @@ export class Stream {
     if (this.#content.readSync(buffer)) {
       return buffer
     }
-    throw new EofError()
+    throw Object.assign(new RangeError("Unexpected EOF"), { stack: false })
   }
 
   /** Capture next bytes until matching regex sequence (length can be used for regex with lookbehind) */
@@ -94,7 +94,7 @@ export class Stream {
         this.read(1)
       }
     } catch (error) {
-      if (error instanceof EofError) {
+      if (error instanceof RangeError) {
         return
       }
       throw error

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -112,12 +112,12 @@ export const schema = {
 
 /** Seek mode */
 export const SeekMode = Object.freeze({
-  Current: Deno?.SeekMode?.Current ?? 0,
-  Start: Deno?.SeekMode?.Start ?? 1,
-  End: Deno?.SeekMode?.End ?? 2,
+  Start: 0,
+  Current: 1,
+  End: 2,
 }) as {
-  Current: Deno.SeekMode.Current
   Start: Deno.SeekMode.Start
+  Current: Deno.SeekMode.Current
   End: Deno.SeekMode.End
 }
 
@@ -218,6 +218,3 @@ export const tokens = {
     },
   },
 } as const
-
-/** End Of File error */
-export const EofError = (Deno?.errors?.UnexpectedEof ?? RangeError) as ErrorConstructor

--- a/utils/utils_test.ts
+++ b/utils/utils_test.ts
@@ -1,6 +1,6 @@
 import { Streamable } from "./streamable.ts"
 import { Stream } from "./stream.ts"
-import { EofError, SeekMode } from "./types.ts"
+import { SeekMode } from "./types.ts"
 import { expect } from "https://deno.land/std@0.223.0/expect/expect.ts"
 
 Deno.test("streamable: readSync", () => {
@@ -48,7 +48,7 @@ Deno.test("stream: read", () => {
   expect(stream.read(5)).toEqual(new TextEncoder().encode("hello"))
   expect(stream.cursor).toBe(5)
   expect(stream.read(6)).toEqual(new TextEncoder().encode(" world"))
-  expect(() => stream.read(1000)).toThrow(EofError)
+  expect(() => stream.read(1000)).toThrow(RangeError)
 })
 
 Deno.test("stream: capture", () => {


### PR DESCRIPTION
Move away from Deno namespace to ensure compatibility with any runtime