### PR TITLE
fix(xml): add missing 's' to '#instructions' in clone/doc

### DIFF
--- a/xml/parse.ts
+++ b/xml/parse.ts
@@ -82,7 +82,7 @@ export type options = {
  *   - `readonly ["#text"]?: string`: concatenated children text content, this property becomes enumerable if at least one non-empty text node is present
  * - XML document properties
  *  - `["#doctype"]?: xml_node`: XML doctype
- *  - `["#instruction"]?: { [key:string]: xml_node| Array<xml_node> }`: XML processing instructions
+ *  - `["#instructions"]?: { [key:string]: xml_node| Array<xml_node> }`: XML processing instructions
  *
  * Attributes are prefixed with an arobase (`@`).
  *

--- a/xml/stringify.ts
+++ b/xml/stringify.ts
@@ -112,7 +112,7 @@ function clone(document: Record<PropertyKey, unknown>) {
   for (const property in document) {
     cloned[property] = ((document[property] !== null) && (["object", "function"].includes(typeof document[property]))) ? clone(document[property] as Record<PropertyKey, unknown>) : document[property]
   }
-  ;["~name", "~parent", "#text", "~children", "#comments", "#text", "#doctype", "#instruction", internal].forEach((property) => {
+  ;["~name", "~parent", "#text", "~children", "#comments", "#text", "#doctype", "#instructions", internal].forEach((property) => {
     if (property in document) {
       Object.defineProperty(cloned, property, Object.getOwnPropertyDescriptor(document, property)!)
     }


### PR DESCRIPTION
While taking a look at #96, noticed that doc and clone method referenced `#instruction` but it is actual defined as plural `#instructions` in the code
https://github.com/lowlighter/libs/blob/2969d110e052b4eff16a10d491b24c20d2fd12fe/xml/parse.ts#L172-L176